### PR TITLE
Override /actuator/prometheus endpoint

### DIFF
--- a/kustomize/base/flais.yaml
+++ b/kustomize/base/flais.yaml
@@ -49,6 +49,11 @@ spec:
       failureThreshold: 5
       periodSeconds: 10
       timeoutSeconds: 3
+  observability:
+    metrics:
+      enabled: true
+      port: 8080
+      path: /actuator/prometheus
   restartPolicy: Always
   replicas: 1
   strategy:

--- a/kustomize/overlays/afk-no/api/kustomization.yaml
+++ b/kustomize/overlays/afk-no/api/kustomization.yaml
@@ -27,6 +27,9 @@ patches:
       - op: replace
         path: "/spec/probes/readiness/path"
         value: "/afk-no/actuator/health"
+      - op: replace
+        path: "/spec/observability/metrics/path"
+        value: "/afk-no/actuator/prometheus"
 
     target:
       kind: Application

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -27,6 +27,9 @@ patches:
       - op: replace
         path: "/spec/probes/readiness/path"
         value: "/beta/afk-no/actuator/health"
+      - op: replace
+        path: "/spec/observability/metrics/path"
+        value: "/beta/afk-no/actuator/prometheus"
 
     target:
       kind: Application

--- a/kustomize/overlays/bfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/api/kustomization.yaml
@@ -27,6 +27,9 @@ patches:
       - op: replace
         path: "/spec/probes/readiness/path"
         value: "/bfk-no/actuator/health"
+      - op: replace
+        path: "/spec/observability/metrics/path"
+        value: "/bfk-no/actuator/prometheus"
     target:
       kind: Application
       name: fint-flyt-acos-discovery-gateway

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -27,6 +27,9 @@ patches:
       - op: replace
         path: "/spec/probes/readiness/path"
         value: "/beta/bfk-no/actuator/health"
+      - op: replace
+        path: "/spec/observability/metrics/path"
+        value: "/beta/bfk-no/actuator/prometheus"
 
     target:
       kind: Application

--- a/kustomize/overlays/ofk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/api/kustomization.yaml
@@ -27,6 +27,9 @@ patches:
       - op: replace
         path: "/spec/probes/readiness/path"
         value: "/ofk-no/actuator/health"
+      - op: replace
+        path: "/spec/observability/metrics/path"
+        value: "/ofk-no/actuator/prometheus"
 
     target:
       kind: Application

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -27,6 +27,9 @@ patches:
       - op: replace
         path: "/spec/probes/readiness/path"
         value: "/beta/ofk-no/actuator/health"
+      - op: replace
+        path: "/spec/observability/metrics/path"
+        value: "/beta/ofk-no/actuator/prometheus"
 
     target:
       kind: Application


### PR DESCRIPTION
This is necessary for Prometheus to be able to scrape metrics as basePath has been overridden, then /actuator/prometheus is no longer valid.